### PR TITLE
Remove double `resources` entry

### DIFF
--- a/daemon.yaml
+++ b/daemon.yaml
@@ -28,7 +28,6 @@ spec:
       hostNetwork: true
       containers:
         - name: k8s-custom-iptables
-          resources:
           securityContext:
             privileged: true
           image: gcr.io/google_containers/k8s-custom-iptables:1.0


### PR DESCRIPTION
The `k8s-custom-iptables` container had defined `resources` twice